### PR TITLE
expand meta-data options panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ DerivedData
 *.xcworkspace
 *.xcuserdatad
 
+.DS_Store

--- a/JPEG to DICOM/DCMJpegImportFilter.m
+++ b/JPEG to DICOM/DCMJpegImportFilter.m
@@ -70,8 +70,10 @@
         [openPanel setTitle:NSLocalizedString( @"Import", nil)];
         [openPanel setMessage:NSLocalizedString( @"Select image or folder of images to convert to DICOM", nil)];
         
-        if( supportCustomMetaData)
+        if( supportCustomMetaData) {
             [openPanel setAccessoryView: accessoryView];
+            [openPanel setAccessoryViewDisclosed:YES];
+        }
         
         if( [openPanel runModalForTypes:[NSImage imageFileTypes]] == NSOKButton)
         {


### PR DESCRIPTION
With options panel not opened by default, it wasn't obvious to the user that he could change DICOM tags or use the ones of the patient/series selected.